### PR TITLE
allow for null value for Calendar input

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -19,7 +19,7 @@ module.exports = React.createClass({
             date: date,
             format: format,
             computableFormat: computableFormat,
-            inputValue: date.format(format),
+            inputValue: null,
             views: ['days', 'months', 'years'],
             currentView: 0,
             isVisible: false
@@ -69,15 +69,21 @@ module.exports = React.createClass({
 
     inputBlur: function () {
         var date = this.state.inputValue;
-        var format = this.state.format;
-        var newDate = moment(date, format).isValid() ? moment(date, format) : moment();
+        var newDate = null;
+        var computableDate = null;
+        if (date) {
+            var format = this.state.format;
+            newDate = moment(date, format).isValid() ? moment(date, format) : moment();
+            computableDate = newDate.format(this.state.computableFormat);
+            newDate = newDate.format(format);
+        }
 
         this.setState({
             date: newDate,
-            inputValue: newDate.format(format)
+            inputValue: newDate
         });
         if (this.props.onChange) {
-            this.props.onChange(newDate.format(this.state.computableFormat));
+            this.props.onChange(computableDate);
         }
     },
 

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -32,7 +32,7 @@ module.exports = React.createClass({
     cellClick: function (e) {
         var cell = e.target,
             date = parseInt(cell.innerHTML, 10),
-            newDate = this.props.date;
+            newDate = this.props.date ? this.props.date : moment();
 
         if (isNaN(date)) {
             return;
@@ -50,7 +50,7 @@ module.exports = React.createClass({
 
 
     getDays: function () {
-        var now = this.props.date,
+        var now = this.props.date ? this.props.date : moment(),
             start = now.clone().startOf('month').day(0),
             end = now.clone().endOf('month').day(6),
             month = now.month(),
@@ -89,7 +89,7 @@ module.exports = React.createClass({
             return <Cell value={item.label} classes={_class} key={i} />
         });
 
-        var currentDate = this.props.date.format('MMMM');
+        var currentDate = this.props.date ? this.props.date.format('MMMM') : moment().format('MMMM');
 
         return (
             <div className="view days-view" onKeyDown={this.keyDown}>


### PR DESCRIPTION
It wasn't possible with the previous version so I did some changes to allow for a null.

It's basically juste a change in the onBlur event and some checks in DaysView but it may be worth checking if nothing is broken by theses changes. 
