### PR TITLE
not null value was not displayed on initialize

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -37,6 +37,13 @@ module.exports = React.createClass({
         document.removeEventListener('click', this.documentClick);
     },
 
+    componentWillReceiveProps: function(nextProps) {
+        this.setState({
+            date: nextProps.date ? moment(nextProps.date) : null,
+            inputValue: nextProps.date ? moment(nextProps.date).format(this.state.format) : null
+        });
+    },
+
     keyDown: function (e) {
         _keyDownActions.call(this, e.keyCode);
     },


### PR DESCRIPTION
My previous PR was creating a bug when setting a date value on the element at render. No date was displayed.

This PR also allow passing a null value to date prop and not have an "invalid date" on the datepicker.
