### PR TITLE
Better support null date, add placeholder, better parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Default: undefined
 
 Define state when date picker would close once the user has clicked on a date.
 
+#### props.placeholder
+
+Type: `String`
+
+Default: undefined
+
+Value to show in the input text box if no date is set.
+
 ## License
 
 MIT

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -97,11 +97,11 @@ module.exports = React.createClass({
 
     inputBlur: function () {
         var date = this.state.inputValue,
-            newDate = null, computableDate = null, format;
-
-        if (date) {
+            newDate = null,
+            computableDate = null,
             format = this.state.format;
 
+        if (date) {
             // format, with strict parsing true, so we catch bad dates
             newDate = moment(date, format, true);
 
@@ -123,7 +123,7 @@ module.exports = React.createClass({
 
         this.setState({
             date: newDate,
-            inputValue: computableDate
+            inputValue: newDate ? newDate.format(format) : null
         });
 
         if (this.props.onChange) {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -101,7 +101,23 @@ module.exports = React.createClass({
 
         if (date) {
             format = this.state.format;
-            newDate = moment(date, format).isValid() ? moment(date, format) : moment();
+
+            // format, with strict parsing true, so we catch bad dates
+            newDate = moment(date, format, true);
+
+            // if the new date didn't match our format, see if the native
+            // js date can parse it
+            if (!newDate.isValid()) {
+                var d = new Date(date);
+
+                // if native js cannot parse, just make a new date
+                if (isNaN(d.getTime())) {
+                    d = new Date();
+                }
+
+                newDate = moment(d);
+            }
+
             computableDate = newDate.format(this.state.computableFormat);
         }
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -10,8 +10,18 @@ var _keyDownActions = Utils.keyDownActions;
 
 module.exports = React.createClass({
 
+    propTypes: {
+        closeOnSelect: React.PropTypes.bool,
+        computableFormat: React.PropTypes.string,
+        date: React.PropTypes.any,
+        format: React.PropTypes.string,
+        minView: React.PropTypes.number,
+        onChange: React.PropTypes.func,
+        placeholder: React.PropTypes.string
+    },
+
     getInitialState: function() {
-        var date = this.props.date ? moment(this.props.date) : moment(),
+        var date = this.props.date ? moment(this.props.date) : null,
             format = this.props.format || 'MM-DD-YYYY',
             minView = parseInt(this.props.minView, 10) || 0,
             computableFormat = this.props.computableFormat || 'MM-DD-YYYY';
@@ -149,24 +159,30 @@ module.exports = React.createClass({
     },
 
     render: function () {
+
+        // its ok for this.state.date to be null, but we should never
+        // pass null for the date into the calendar pop up, as we want
+        // it to just start on todays date if there is no date set
+        var calendarDate = this.state.date || moment();
+
         var view;
         switch (this.state.currentView) {
             case 0:
                 view = <DaysView
-                    date={this.state.date}
+                    date={calendarDate}
                     setDate={this.setDate}
                     nextView={this.nextView} />;
                 break;
             case 1:
                 view = <MonthsView
-                    date={this.state.date}
+                    date={calendarDate}
                     setDate={this.setDate}
                     nextView={this.nextView}
                     prevView={this.prevView} />;
                 break;
             case 2:
                 view = <YearsView
-                    date={this.state.date}
+                    date={calendarDate}
                     setDate={this.setDate}
                     prevView={this.prevView} />;
                 break;
@@ -189,7 +205,8 @@ module.exports = React.createClass({
                     className="input-calendar-value"
                     value={this.state.inputValue}
                     onBlur={this.inputBlur}
-                    onChange={this.changeDate} />
+                    onChange={this.changeDate}
+                    placeholder={this.props.placeholder} />
 
                 <span onClick={this.toogleClick} className="icon-wrapper calendar-icon">
                     <i className={iconClass}></i>

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -7,7 +7,7 @@ var ViewHeader = require('./ViewHeader');
 module.exports = React.createClass({
 
     propTypes: {
-        date: React.PropTypes.object,
+        date: React.PropTypes.object.isRequired,
         setDate: React.PropTypes.func,
         nextView: React.PropTypes.func
     },

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -7,7 +7,7 @@ var ViewHeader = require('./ViewHeader');
 module.exports = React.createClass({
 
     propTypes: {
-        date: React.PropTypes.object
+        date: React.PropTypes.object.isRequired
     },
 
     next: function() {


### PR DESCRIPTION
Previously, if the text field was empty (for example if you backspaced the text away), then immediately selected the calendar picker button, clicking the forward / backward buttons would cause a null exception.  Also, passing a null date into the component would show today's date in the text box.  Now null date is an ok thing to pass, and we just create a date to pass into the calendar pieces if we need to.

Added support for placeholder text in the input box, great if you want to start out with an empty date (maybe to display a format suggestion, or an action word).

Added missing propTypes to top of main component.

Fall back to js date parsing if strict moment parsing fails.  This makes the input box much more likely to figure out what date the user typed, even if it didn't match the format we wanted.  For example, now it can figure out odd strings like 20 Feb 13.

Thanks for providing the base component, I love it, hope these changes help someone else out!