### PR TITLE
Fix React warning about React.addons.classSet

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var DaysView = require('./DaysView');
 var MonthsView = require('./MonthsView');

--- a/dist/DaysView.js
+++ b/dist/DaysView.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/dist/MonthsView.js
+++ b/dist/MonthsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/dist/YearsView.js
+++ b/dist/YearsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "repository": "https://github.com/Rudeg/react-input-calendar",
   "main": "index.js",
   "dependencies": {
-    "react": "^0.13.3",
+    "classname": "0.0.0",
     "envify": "^3.4.0",
-    "reactify": "^1.1.1",
-    "moment-range": "^1.0.5"
+    "moment-range": "^1.0.5",
+    "react": "^0.13.3",
+    "reactify": "^1.1.1"
   },
   "devDependencies": {
     "browserify": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "https://github.com/Rudeg/react-input-calendar",
   "main": "index.js",
   "dependencies": {
+    "classnames": "^2.1.3",
     "envify": "^3.4.0",
     "moment-range": "^1.0.5",
     "react": "^0.13.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "https://github.com/Rudeg/react-input-calendar",
   "main": "index.js",
   "dependencies": {
-    "classname": "0.0.0",
     "envify": "^3.4.0",
     "moment-range": "^1.0.5",
     "react": "^0.13.3",

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var DaysView = require('./DaysView');
 var MonthsView = require('./MonthsView');

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = require('classname');
+var cs = require('classnames');
 var moment = require('moment-range');
 var DaysView = require('./DaysView');
 var MonthsView = require('./MonthsView');

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = require('classname');
+var cs = require('classnames');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -1,5 +1,5 @@
 var React = require('react/addons');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = require('classname');
+var cs = require('classnames');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = require('classname');
+var cs = require('classnames');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -1,5 +1,5 @@
 var React = require('react');
-var cs = React.addons.classSet;
+var cs = require('classname');
 var moment = require('moment-range');
 var Cell = require('./Cell');
 var ViewHeader = require('./ViewHeader');


### PR DESCRIPTION
`Warning: React.addons.classSet will be deprecated in a future version. See http://fb.me/react-addons-classset`

Make use of standalone package from [JedWatson/classnames](https://github.com/JedWatson/classnames) instead of React.addons.classSet