### PR TITLE
Only use onFocus when openOnInputFocus option is set

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -233,7 +233,6 @@ module.exports = React.createClass({displayName: "exports",
                     value: this.state.inputValue, 
                     onBlur: this.inputBlur, 
                     onChange: this.changeDate, 
-                    onClick: this.props.openOnInputFocus ? this.toggleClick : '', 
                     onFocus: this.props.openOnInputFocus ? this.toggleClick : '', 
                     placeholder: this.props.placeholder}), 
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -233,7 +233,6 @@ module.exports = React.createClass({
                     value={this.state.inputValue}
                     onBlur={this.inputBlur}
                     onChange={this.changeDate}
-                    onClick={this.props.openOnInputFocus ? this.toggleClick : ''}
                     onFocus={this.props.openOnInputFocus ? this.toggleClick : ''}
                     placeholder={this.props.placeholder} />
 


### PR DESCRIPTION
After looking closer at #23, I see there was a bug introduced.

``` js
onClick: this.props.openOnInputFocus ? this.toggleClick : '',
onFocus: this.props.openOnInputFocus ? this.toggleClick : '',
```

The issue comes from the fact that `onClick` calls `this.toggleClick` which in turn causes `onFocus` to be called. This then results in `this.toggleClick` being called a second time. The calendar will open and close with a single click.

It would be better to only use `onFocus` since `onClick` is redundant.