### PR TITLE
Allow selection to be limited within a date range

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -14,6 +14,8 @@ module.exports = React.createClass({displayName: "exports",
         closeOnSelect: React.PropTypes.bool,
         computableFormat: React.PropTypes.string,
         date: React.PropTypes.any,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any,
         format: React.PropTypes.string,
         minView: React.PropTypes.number,
         onBlur: React.PropTypes.func,
@@ -24,12 +26,16 @@ module.exports = React.createClass({displayName: "exports",
 
     getInitialState: function() {
         var date = this.props.date ? moment(this.props.date) : null,
+            minDate = this.props.minDate ? moment(this.props.minDate) : null,
+            maxDate = this.props.maxDate ? moment(this.props.maxDate) : null,
             format = this.props.format || 'MM-DD-YYYY',
             minView = parseInt(this.props.minView, 10) || 0,
             computableFormat = this.props.computableFormat || 'MM-DD-YYYY';
 
         return {
             date: date,
+            minDate: minDate,
+            maxDate: maxDate,
             format: format,
             computableFormat: computableFormat,
             inputValue: date ? date.format(format) : null,
@@ -59,13 +65,37 @@ module.exports = React.createClass({displayName: "exports",
         _keyDownActions.call(this, e.keyCode);
     },
 
+    checkIfDateDisabled: function (date) {
+        if (this.state.minDate && date.isBefore(this.state.minDate)) {
+            return true;
+        }
+
+        if (this.state.maxDate && date.isAfter(this.state.maxDate)) {
+            return true;
+        }
+
+        return false;
+    },
+
     nextView: function () {
+        if (this.checkIfDateDisabled(this.state.date)) {
+            return;
+        }
+
         this.setState({
             currentView: ++this.state.currentView
         });
     },
 
     prevView: function (date) {
+        if (this.state.minDate && date.isBefore(this.state.minDate)) {
+            date = this.state.minDate.clone();
+        }
+
+        if (this.state.maxDate && date.isAfter(this.state.maxDate)) {
+            date = this.state.maxDate.clone();
+        }
+
         if (this.state.currentView === this.state.minView) {
             this.setState({
                 date: date,
@@ -86,6 +116,10 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     setDate: function (date, isDayView) {
+        if (this.checkIfDateDisabled(date)) {
+            return;
+        }
+
         this.setState({
             date: date,
             inputValue: date.format(this.state.format),
@@ -158,7 +192,9 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     todayClick: function () {
-        var today = moment();
+        var today = moment().startOf('day');
+
+        if (this.checkIfDateDisabled(today)) return;
 
         this.setState({
             date: today,
@@ -198,12 +234,16 @@ module.exports = React.createClass({displayName: "exports",
             case 0:
                 view = React.createElement(DaysView, {
                     date: calendarDate, 
+                    minDate: this.state.minDate, 
+                    maxDate: this.state.maxDate, 
                     setDate: this.setDate, 
                     nextView: this.nextView});
                 break;
             case 1:
                 view = React.createElement(MonthsView, {
                     date: calendarDate, 
+                    minDate: this.state.minDate, 
+                    maxDate: this.state.maxDate, 
                     setDate: this.setDate, 
                     nextView: this.nextView, 
                     prevView: this.prevView});
@@ -211,6 +251,8 @@ module.exports = React.createClass({displayName: "exports",
             case 2:
                 view = React.createElement(YearsView, {
                     date: calendarDate, 
+                    minDate: this.state.minDate, 
+                    maxDate: this.state.maxDate, 
                     setDate: this.setDate, 
                     prevView: this.prevView});
                 break;
@@ -218,7 +260,12 @@ module.exports = React.createClass({displayName: "exports",
 
         var calendar = !this.state.isVisible ? '' :
             React.createElement("div", {className: "input-calendar-wrapper", onClick: this.calendarClick}, 
-                view, React.createElement("span", {className: "today-btn", onClick: this.todayClick}, "Today")
+                view, 
+                React.createElement("span", {
+                  className: "today-btn" + (this.checkIfDateDisabled(moment().startOf('day')) ? " disabled" : ""), 
+                  onClick: this.todayClick}, 
+                  "Today"
+                )
             );
 
         var iconClass = cs({

--- a/dist/DaysView.js
+++ b/dist/DaysView.js
@@ -8,6 +8,8 @@ module.exports = React.createClass({displayName: "exports",
 
     propTypes: {
         date: React.PropTypes.object.isRequired,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any,
         setDate: React.PropTypes.func,
         nextView: React.PropTypes.func
     },
@@ -22,17 +24,29 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     next: function() {
-        this.props.setDate(this.props.date.add(1, 'months'));
+        var nextDate = this.props.date.clone().add(1, 'months');
+
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+            nextDate = this.props.maxDate;
+        }
+
+        this.props.setDate(nextDate);
     },
 
     prev: function() {
-        this.props.setDate(this.props.date.subtract(1, 'months'));
+        var prevDate = this.props.date.clone().subtract(1, 'months');
+
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+            prevDate = this.props.minDate;
+        }
+
+        this.props.setDate(prevDate);
     },
 
     cellClick: function (e) {
         var cell = e.target,
             date = parseInt(cell.innerHTML, 10),
-            newDate = this.props.date ? this.props.date : moment();
+            newDate = this.props.date ? this.props.date.clone() : moment();
 
         if (isNaN(date)) {
             return;
@@ -53,6 +67,8 @@ module.exports = React.createClass({displayName: "exports",
         var now = this.props.date ? this.props.date : moment(),
             start = now.clone().startOf('month').day(0),
             end = now.clone().endOf('month').day(6),
+            minDate = this.props.minDate,
+            maxDate = this.props.maxDate,
             month = now.month(),
             today = moment(),
             currDay = now.date(),
@@ -66,6 +82,7 @@ module.exports = React.createClass({displayName: "exports",
                     label: day.format('D'),
                     prev: (day.month() < month && !(day.year() > year)) || day.year() < year ,
                     next: day.month() > month || day.year() > year,
+                    disabled: day.isBefore(minDate) || day.isAfter(maxDate),
                     curr: day.date() === currDay && day.month() === month,
                     today: day.date() === today.date() && day.month() === today.month()
                 });
@@ -84,6 +101,7 @@ module.exports = React.createClass({displayName: "exports",
                 'day': true,
                 'next': item.next,
                 'prev': item.prev,
+                'disabled': item.disabled,
                 'current': item.curr,
                 'today': item.today
             });

--- a/dist/YearsView.js
+++ b/dist/YearsView.js
@@ -8,17 +8,36 @@ module.exports = React.createClass({displayName: "exports",
 
     propTypes: {
         date: React.PropTypes.object,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any,
         changeView: React.PropTypes.func
     },
 
     years: [],
 
+    checkIfYearDisabled: function (year) {
+        return year.clone().endOf('year').isBefore(this.props.minDate) ||
+            year.clone().startOf('year').isAfter(this.props.maxDate);
+    },
+
     next: function() {
-        this.props.setDate(this.props.date.add(10, 'years'));
+        var nextDate = this.props.date.clone().add(10, 'years');
+
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+            nextDate = this.props.maxDate;
+        }
+
+        this.props.setDate(nextDate);
     },
 
     prev: function() {
-        this.props.setDate(this.props.date.subtract(10, 'years'));
+        var prevDate = this.props.date.clone().subtract(10, 'years');
+
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+            prevDate = this.props.minDate;
+        }
+
+        this.props.setDate(prevDate);
     },
 
     rangeCheck: function (currYear) {
@@ -46,17 +65,23 @@ module.exports = React.createClass({displayName: "exports",
             .by('years', function(year) {
                 items.push({
                     label: year.format('YYYY'),
+                    disabled: this.checkIfYearDisabled(year),
                     curr: currYear === year.year()
                 });
-            });
-        
+            }.bind(this));
+
         this.years = items;
         return items;
     },
-    
+
     cellClick: function (e) {
         var year = parseInt(e.target.innerHTML, 10);
-        var date = this.props.date.year(year);
+        var date = this.props.date.clone().year(year);
+
+        if (this.checkIfYearDisabled(date)) {
+            return;
+        }
+
         this.props.prevView(date);
     },
 
@@ -68,6 +93,7 @@ module.exports = React.createClass({displayName: "exports",
         var yearsCells = years.map(function (item, i) {
             var _class = cs({
                 'year': true,
+                'disabled': item.disabled,
                 'current': item.label == currYear
             });
             return React.createElement(Cell, {value: item.label, classes: _class, key: i})

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -8,6 +8,8 @@ module.exports = React.createClass({
 
     propTypes: {
         date: React.PropTypes.object.isRequired,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any,
         setDate: React.PropTypes.func,
         nextView: React.PropTypes.func
     },
@@ -22,17 +24,29 @@ module.exports = React.createClass({
     },
 
     next: function() {
-        this.props.setDate(this.props.date.add(1, 'months'));
+        var nextDate = this.props.date.clone().add(1, 'months');
+
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+            nextDate = this.props.maxDate;
+        }
+
+        this.props.setDate(nextDate);
     },
 
     prev: function() {
-        this.props.setDate(this.props.date.subtract(1, 'months'));
+        var prevDate = this.props.date.clone().subtract(1, 'months');
+
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+            prevDate = this.props.minDate;
+        }
+
+        this.props.setDate(prevDate);
     },
 
     cellClick: function (e) {
         var cell = e.target,
             date = parseInt(cell.innerHTML, 10),
-            newDate = this.props.date ? this.props.date : moment();
+            newDate = this.props.date ? this.props.date.clone() : moment();
 
         if (isNaN(date)) {
             return;
@@ -53,6 +67,8 @@ module.exports = React.createClass({
         var now = this.props.date ? this.props.date : moment(),
             start = now.clone().startOf('month').day(0),
             end = now.clone().endOf('month').day(6),
+            minDate = this.props.minDate,
+            maxDate = this.props.maxDate,
             month = now.month(),
             today = moment(),
             currDay = now.date(),
@@ -66,6 +82,7 @@ module.exports = React.createClass({
                     label: day.format('D'),
                     prev: (day.month() < month && !(day.year() > year)) || day.year() < year ,
                     next: day.month() > month || day.year() > year,
+                    disabled: day.isBefore(minDate) || day.isAfter(maxDate),
                     curr: day.date() === currDay && day.month() === month,
                     today: day.date() === today.date() && day.month() === today.month()
                 });
@@ -84,6 +101,7 @@ module.exports = React.createClass({
                 'day': true,
                 'next': item.next,
                 'prev': item.prev,
+                'disabled': item.disabled,
                 'current': item.curr,
                 'today': item.today
             });

--- a/src/MonthsView.js
+++ b/src/MonthsView.js
@@ -7,20 +7,46 @@ var ViewHeader = require('./ViewHeader');
 module.exports = React.createClass({
 
     propTypes: {
-        date: React.PropTypes.object.isRequired
+        date: React.PropTypes.object.isRequired,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any
+    },
+
+    checkIfMonthDisabled: function (month) {
+        var now = this.props.date;
+
+        return now.clone().month(month).endOf('month').isBefore(this.props.minDate) ||
+            now.clone().month(month).startOf('month').isAfter(this.props.maxDate);
     },
 
     next: function() {
-        this.props.setDate(this.props.date.add(1, 'years'));
+        var nextDate = this.props.date.clone().add(1, 'years');
+
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+            nextDate = this.props.maxDate;
+        }
+
+        this.props.setDate(nextDate);
     },
 
     prev: function() {
-        this.props.setDate(this.props.date.subtract(1, 'years'));
+        var prevDate = this.props.date.clone().subtract(1, 'years');
+
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+            prevDate = this.props.minDate;
+        }
+
+        this.props.setDate(prevDate);
     },
 
     cellClick: function (e) {
         var month = e.target.innerHTML;
-        var date = this.props.date.month(month);
+        var date = this.props.date.clone().month(month);
+
+        if (this.checkIfMonthDisabled(month)) {
+            return;
+        }
+
         this.props.prevView(date);
     },
 
@@ -31,15 +57,17 @@ module.exports = React.createClass({
         return moment.monthsShort().map(function (item, i) {
             return {
                 label: item,
+                disabled: this.checkIfMonthDisabled(i),
                 curr: i === month
             };
-        });
+        }.bind(this));
     },
 
     render: function () {
         var months = this.getMonth().map(function (item, i) {
             var _class = cs({
                 'month': true,
+                'disabled': item.disabled,
                 'current': item.curr
             });
             return <Cell value={item.label} classes={_class} key={i} />

--- a/src/YearsView.js
+++ b/src/YearsView.js
@@ -8,17 +8,36 @@ module.exports = React.createClass({
 
     propTypes: {
         date: React.PropTypes.object,
+        minDate: React.PropTypes.any,
+        maxDate: React.PropTypes.any,
         changeView: React.PropTypes.func
     },
 
     years: [],
 
+    checkIfYearDisabled: function (year) {
+        return year.clone().endOf('year').isBefore(this.props.minDate) ||
+            year.clone().startOf('year').isAfter(this.props.maxDate);
+    },
+
     next: function() {
-        this.props.setDate(this.props.date.add(10, 'years'));
+        var nextDate = this.props.date.clone().add(10, 'years');
+
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+            nextDate = this.props.maxDate;
+        }
+
+        this.props.setDate(nextDate);
     },
 
     prev: function() {
-        this.props.setDate(this.props.date.subtract(10, 'years'));
+        var prevDate = this.props.date.clone().subtract(10, 'years');
+
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+            prevDate = this.props.minDate;
+        }
+
+        this.props.setDate(prevDate);
     },
 
     rangeCheck: function (currYear) {
@@ -46,17 +65,23 @@ module.exports = React.createClass({
             .by('years', function(year) {
                 items.push({
                     label: year.format('YYYY'),
+                    disabled: this.checkIfYearDisabled(year),
                     curr: currYear === year.year()
                 });
-            });
-        
+            }.bind(this));
+
         this.years = items;
         return items;
     },
-    
+
     cellClick: function (e) {
         var year = parseInt(e.target.innerHTML, 10);
-        var date = this.props.date.year(year);
+        var date = this.props.date.clone().year(year);
+
+        if (this.checkIfYearDisabled(date)) {
+            return;
+        }
+
         this.props.prevView(date);
     },
 
@@ -68,6 +93,7 @@ module.exports = React.createClass({
         var yearsCells = years.map(function (item, i) {
             var _class = cs({
                 'year': true,
+                'disabled': item.disabled,
                 'current': item.label == currYear
             });
             return <Cell value={item.label} classes={_class} key={i} />

--- a/styles/input-calendar.css
+++ b/styles/input-calendar.css
@@ -62,10 +62,15 @@
     user-select: none;
 }
 
-.input-calendar .cell:hover {
+.input-calendar .cell:not(.disabled):hover {
     color: #f39c12;
     border: 1px solid #f39c12;
     border-radius: 4px;
+}
+
+.input-calendar .cell.disabled,
+.input-calendar .today-btn.disabled {
+    cursor: default;
 }
 
 .input-calendar .cell.current {
@@ -82,7 +87,9 @@
 }
 
 .input-calendar .day.prev,
-.input-calendar .day.next {
+.input-calendar .day.next,
+.input-calendar .cell.disabled,
+.input-calendar .today-btn.disabled {
     opacity: .4;
 }
 
@@ -137,7 +144,7 @@
 }
 
 .input-calendar .icon:hover,
-.input-calendar .today-btn:hover,
+.input-calendar .today-btn:not(.disabled):hover,
 .input-calendar .icon-wrapper:hover {
     color: #f39c12;
 }


### PR DESCRIPTION
Some things to note:
- Min and max dates are both optional and any previous or later dates will become grayed out / deactivated (including the today button if it is outside of the selectable range)
- I added a clone() onto some of the date manipulations as moment dates are mutable and thus we should clone them if we may potentially not want the actual selected date to change sometimes when navigating around between months or years
- Trying to navigate past the min or max dates will set the selected date to the min or max possible if necessary

Let me know what you think and if there are any changes or additions you'd like :)