### PR TITLE
Prevent calling setState on isVisible if it hasn't changed

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -217,9 +217,11 @@ module.exports = React.createClass({displayName: "exports",
         var eventMethod = value ? 'addEventListener' : 'removeEventListener';
         document[eventMethod]('keydown', this.keyDown);
 
-        this.setState({
-            isVisible: value
-        });
+        if(this.state.isVisible !== value){
+            this.setState({
+                isVisible: value
+            });
+        }
     },
 
     render: function () {

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -217,9 +217,11 @@ module.exports = React.createClass({
         var eventMethod = value ? 'addEventListener' : 'removeEventListener';
         document[eventMethod]('keydown', this.keyDown);
 
-        this.setState({
-            isVisible: value
-        });
+        if(this.state.isVisible !== value){
+            this.setState({
+                isVisible: value
+            });
+        }
     },
 
     render: function () {


### PR DESCRIPTION
## Motivation: 

In the presense of ~25 calendar components, any click on the document triggers `.render` call on every one of them. This takes ~35ms on my laptop. 

With this check, no needless work is being done.