### PR TITLE
Support german weekdays and today button

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -260,13 +260,17 @@ module.exports = React.createClass({displayName: "exports",
                 break;
         }
 
+        var todayText = 'Today';
+        if(moment.locale() === 'de')
+          todayText = 'Heute';
+
         var calendar = !this.state.isVisible ? '' :
             React.createElement("div", {className: "input-calendar-wrapper", onClick: this.calendarClick}, 
                 view, 
                 React.createElement("span", {
                   className: "today-btn" + (this.checkIfDateDisabled(moment().startOf('day')) ? " disabled" : ""), 
                   onClick: this.todayClick}, 
-                  "Today"
+                  todayText
                 )
             );
 

--- a/dist/DaysView.js
+++ b/dist/DaysView.js
@@ -15,6 +15,16 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     getDaysTitles: function () {
+        
+        if(moment.locale() === 'de') {
+          return 'Mo_Di_Mi_Do_Fr_Sa_So'.split('_').map(function (item) {
+              return {
+                  val: item,
+                  label: item
+              };
+          });
+        }        
+        
         return moment.weekdaysMin().map(function (item) {
             return {
                 val: item,
@@ -65,8 +75,8 @@ module.exports = React.createClass({displayName: "exports",
 
     getDays: function () {
         var now = this.props.date ? this.props.date : moment(),
-            start = now.clone().startOf('month').day(0),
-            end = now.clone().endOf('month').day(6),
+            start = now.clone().startOf('month').weekday(0),
+            end = now.clone().endOf('month').weekday(6),
             minDate = this.props.minDate,
             maxDate = this.props.maxDate,
             month = now.month(),


### PR DESCRIPTION
Weekdays in germany start usually with monday.
- if the 'day' function is used in DaysView.js it is not locale aware.
- translation for "Today" to german.