### PR TITLE
Support german weekdays and today button (again)

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -267,6 +267,10 @@ module.exports = React.createClass({displayName: "exports",
                     prevView: this.prevView});
                 break;
         }
+        
+        var todayText = 'Today';
+        if(moment.locale() === 'de')
+          todayText = 'Heute';
 
         var calendar = !this.state.isVisible ? '' :
             React.createElement("div", {className: "input-calendar-wrapper", onClick: this.calendarClick}, 
@@ -274,7 +278,7 @@ module.exports = React.createClass({displayName: "exports",
                 React.createElement("span", {
                   className: "today-btn" + (this.checkIfDateDisabled(moment().startOf('day')) ? " disabled" : ""), 
                   onClick: this.todayClick}, 
-                  "Today"
+                  todayText
                 )
             );
 

--- a/dist/DaysView.js
+++ b/dist/DaysView.js
@@ -16,6 +16,16 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     getDaysTitles: function () {
+        
+        if(moment.locale() === 'de') {
+          return 'Mo_Di_Mi_Do_Fr_Sa_So'.split('_').map(function (item) {
+              return {
+                  val: item,
+                  label: item
+              };
+          });
+        }    
+        
         return moment.weekdaysMin().map(function (item) {
             return {
                 val: item,
@@ -66,8 +76,8 @@ module.exports = React.createClass({displayName: "exports",
 
     getDays: function () {
         var now = this.props.date ? this.props.date : moment(),
-            start = now.clone().startOf('month').day(0),
-            end = now.clone().endOf('month').day(6),
+            start = now.clone().startOf('month').weekday(0),
+            end = now.clone().endOf('month').weekday(6),
             minDate = this.props.minDate,
             maxDate = this.props.maxDate,
             month = now.month(),


### PR DESCRIPTION
after the pull request https://github.com/Rudeg/react-input-calendar/pull/35 deleted my changes accidentally, here is a new pull request for a german date format and german date button.
the same changes as in https://github.com/Rudeg/react-input-calendar/pull/34
