### PR TITLE
No longer mutate props as they are frozen.

### DIFF
--- a/dist/Calendar.js
+++ b/dist/Calendar.js
@@ -267,7 +267,7 @@ module.exports = React.createClass({displayName: "exports",
                     prevView: this.prevView});
                 break;
         }
-        
+
         var todayText = 'Today';
         if(moment.locale() === 'de')
           todayText = 'Heute';

--- a/dist/Cell.js
+++ b/dist/Cell.js
@@ -10,11 +10,10 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     render: function () {
-        var prop = this.props;
-        prop.classes += ' cell';
+        var classes = this.props.classes + ' cell';
 
         return (
-            React.createElement("div", {className: prop.classes}, prop.value)
+            React.createElement("div", {className: classes}, this.props.value)
         );
     }
 

--- a/dist/DaysView.js
+++ b/dist/DaysView.js
@@ -16,7 +16,6 @@ module.exports = React.createClass({displayName: "exports",
     },
 
     getDaysTitles: function () {
-        
         if(moment.locale() === 'de') {
           return 'Mo_Di_Mi_Do_Fr_Sa_So'.split('_').map(function (item) {
               return {
@@ -24,8 +23,8 @@ module.exports = React.createClass({displayName: "exports",
                   label: item
               };
           });
-        }    
-        
+        }
+
         return moment.weekdaysMin().map(function (item) {
             return {
                 val: item,

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -268,13 +268,17 @@ module.exports = React.createClass({
                 break;
         }
 
+        var todayText = 'Today';
+        if(moment.locale() === 'de')
+          todayText = 'Heute';
+
         var calendar = !this.state.isVisible ? '' :
             <div className="input-calendar-wrapper" onClick={this.calendarClick}>
                 {view}
                 <span
                   className={"today-btn" + (this.checkIfDateDisabled(moment().startOf('day')) ? " disabled" : "")}
                   onClick={this.todayClick}>
-                  Today
+                  {todayText}
                 </span>
             </div>;
 

--- a/src/Cell.js
+++ b/src/Cell.js
@@ -10,11 +10,10 @@ module.exports = React.createClass({
     },
 
     render: function () {
-        var prop = this.props;
-        prop.classes += ' cell';
+        var classes = this.props.classes + ' cell';
 
         return (
-            <div className={prop.classes}>{prop.value}</div>
+            React.createElement("div", {className: classes}, this.props.value)
         );
     }
 

--- a/src/DaysView.js
+++ b/src/DaysView.js
@@ -16,6 +16,15 @@ module.exports = React.createClass({
     },
 
     getDaysTitles: function () {
+        if(moment.locale() === 'de') {
+          return 'Mo_Di_Mi_Do_Fr_Sa_So'.split('_').map(function (item) {
+              return {
+                  val: item,
+                  label: item
+              };
+          });
+        }
+
         return moment.weekdaysMin().map(function (item) {
             return {
                 val: item,
@@ -66,8 +75,8 @@ module.exports = React.createClass({
 
     getDays: function () {
         var now = this.props.date ? this.props.date : moment(),
-            start = now.clone().startOf('month').day(0),
-            end = now.clone().endOf('month').day(6),
+            start = now.clone().startOf('month').weekday(0),
+            end = now.clone().endOf('month').weekday(6),
             minDate = this.props.minDate,
             maxDate = this.props.maxDate,
             month = now.month(),


### PR DESCRIPTION
In current react props can no longer be just changed. This broke the calendar view as the `cell` class was never applied. This pull request fixes this issue.

I also updated the `src` files to include the german translation additions. It was missing there so running `gulp` to generate `dist` files created wrong artifacts.