### PR TITLE
Fixes css specificity

### DIFF
--- a/styles/input-calendar.css
+++ b/styles/input-calendar.css
@@ -13,7 +13,6 @@
     background-color: #fff;
     width: 189px;
     text-align: center;
-    left: 140px;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -moz-user-select: none;
@@ -73,7 +72,7 @@
     cursor: default;
 }
 
-.input-calendar .cell.current {
+.input-calendar .cell:not(.disabled).current {
     background: #f39c12;
     color: #fff;
     border-radius: 4px;

--- a/styles/input-calendar.css
+++ b/styles/input-calendar.css
@@ -13,6 +13,7 @@
     background-color: #fff;
     width: 189px;
     text-align: center;
+    left: 140px;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -moz-user-select: none;


### PR DESCRIPTION
Commit f999f81340809c5552ae0bc5e4849f4b4afbbe8d changed a css selector and made it so that hovering over a selected date made the text the same color as the background.

This updates the :hover selector for the selected cell so that the text color is white.