### PR TITLE
Fix minDate and maxDate precision bug

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -73,10 +73,10 @@ module.exports = React.createClass({
     },
 
     checkIfDateDisabled: function (date) {
-        if (date && this.state.minDate && date.isBefore(this.state.minDate)) {
+        if (date && this.state.minDate && date.isBefore(this.state.minDate, 'day')) {
             return true
         }
-        if (date && this.state.maxDate && date.isAfter(this.state.maxDate)) {
+        if (date && this.state.maxDate && date.isAfter(this.state.maxDate, 'day')) {
             return true
         }
         return false
@@ -88,11 +88,11 @@ module.exports = React.createClass({
     },
 
     prevView: function (date) {
-        if (this.state.minDate && date.isBefore(this.state.minDate)) {
+        if (this.state.minDate && date.isBefore(this.state.minDate, 'day')) {
             date = this.state.minDate.clone()
         }
 
-        if (this.state.maxDate && date.isAfter(this.state.maxDate)) {
+        if (this.state.maxDate && date.isAfter(this.state.maxDate, 'day')) {
             date = this.state.maxDate.clone()
         }
 

--- a/src/day-view.js
+++ b/src/day-view.js
@@ -29,7 +29,7 @@ class DayView extends React.Component {
 
     next() {
         let nextDate = this.props.date.clone().add(1, 'months')
-        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate, 'day')) {
           nextDate = this.props.maxDate
         }
         this.props.setDate(nextDate)
@@ -37,7 +37,7 @@ class DayView extends React.Component {
 
     prev() {
         let prevDate = this.props.date.clone().subtract(1, 'months')
-        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate, 'day')) {
           prevDate = this.props.minDate
         }
         this.props.setDate(prevDate)
@@ -79,7 +79,7 @@ class DayView extends React.Component {
               label: day.format('D'),
               prev: (day.month() < month && !(day.year() > year)) || day.year() < year ,
               next: day.month() > month || day.year() > year,
-              disabled: day.isBefore(minDate) || day.isAfter(maxDate),
+              disabled: day.isBefore(minDate, 'day') || day.isAfter(maxDate, 'day'),
               curr: day.date() === currDay && day.month() === month,
               today: day.date() === today.date() && day.month() === today.month() && day.year() === today.year()
             })

--- a/src/month-view.js
+++ b/src/month-view.js
@@ -18,14 +18,14 @@ module.exports = React.createClass({
     checkIfMonthDisabled: function (month) {
         let now = this.props.date
 
-        return now.clone().month(month).endOf('month').isBefore(this.props.minDate) ||
-            now.clone().month(month).startOf('month').isAfter(this.props.maxDate)
+        return now.clone().month(month).endOf('month').isBefore(this.props.minDate, 'day') ||
+            now.clone().month(month).startOf('month').isAfter(this.props.maxDate, 'day')
     },
 
     next: function() {
         let nextDate = this.props.date.clone().add(1, 'years')
 
-        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate, 'day')) {
             nextDate = this.props.maxDate
         }
 
@@ -35,7 +35,7 @@ module.exports = React.createClass({
     prev: function() {
         let prevDate = this.props.date.clone().subtract(1, 'years')
 
-        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate, 'day')) {
             prevDate = this.props.minDate
         }
 

--- a/src/year-view.js
+++ b/src/year-view.js
@@ -18,14 +18,14 @@ module.exports = React.createClass({
     years: [],
 
     checkIfYearDisabled: function (year) {
-        return year.clone().endOf('year').isBefore(this.props.minDate) ||
-            year.clone().startOf('year').isAfter(this.props.maxDate)
+        return year.clone().endOf('year').isBefore(this.props.minDate, 'day') ||
+            year.clone().startOf('year').isAfter(this.props.maxDate, 'day')
     },
 
     next: function() {
         let nextDate = this.props.date.clone().add(10, 'years')
 
-        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate)) {
+        if (this.props.maxDate && nextDate.isAfter(this.props.maxDate, 'day')) {
             nextDate = this.props.maxDate
         }
 
@@ -35,7 +35,7 @@ module.exports = React.createClass({
     prev: function() {
         let prevDate = this.props.date.clone().subtract(10, 'years')
 
-        if (this.props.minDate && prevDate.isBefore(this.props.minDate)) {
+        if (this.props.minDate && prevDate.isBefore(this.props.minDate, 'day')) {
             prevDate = this.props.minDate
         }
 


### PR DESCRIPTION
Compare minDate and maxDate with a precision of a day instead of milliseconds
See: http://momentjs.com/docs/#/query/