### PR TITLE
Bind next() and prev() to DayView instance

### DIFF
--- a/src/day-view.js
+++ b/src/day-view.js
@@ -10,6 +10,8 @@ class DayView extends React.Component {
     constructor() {
       super()
       this.cellClick = this.cellClick.bind(this)
+      this.next = this.next.bind(this)
+      this.prev = this.prev.bind(this)
     }
 
     static propTypes = {


### PR DESCRIPTION
next() and prev() needs to be bound to DayView instance to prevent 'undefined' issues if minDate or maxDate is set.