### PR TITLE
Add prop to control date parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ Allowed Keys: All formats supported by [moment.js](http://momentjs.com/docs/#/pa
 
 Format of date for the onChange event. Default on the  date format (ISO 8601) to ease the save of data.
 
+#### props.strictDateParsing
+
+Type: `Boolean`
+
+Defaults: false
+
+If set `true`, the parsing process will catch bad dates and does
+not try to parse the date with the native js date function and does not set
+the date to now either. Therefore the computed date will be reported as 'Invalid date'.
+
 #### props.onChange
 
 Type: `Function`

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -14,6 +14,7 @@ module.exports = React.createClass({
     propTypes: {
         closeOnSelect: React.PropTypes.bool,
         computableFormat: React.PropTypes.string,
+        strictDateParsing: React.PropTypes.bool,
         date: React.PropTypes.any,
         minDate: React.PropTypes.any,
         maxDate: React.PropTypes.any,
@@ -37,7 +38,8 @@ module.exports = React.createClass({
             inputFieldClass = this.props.inputFieldClass ? this.props.inputFieldClass : 'input-calendar-value',
             format = this.props.format || 'MM-DD-YYYY',
             minView = parseInt(this.props.minView, 10) || 0,
-            computableFormat = this.props.computableFormat || 'MM-DD-YYYY'
+            computableFormat = this.props.computableFormat || 'MM-DD-YYYY',
+            strictDateParsing = this.props.strictDateParsing || false;
 
         return {
             date: date,
@@ -49,7 +51,8 @@ module.exports = React.createClass({
             views: ['days', 'months', 'years'],
             minView: minView,
             currentView: minView || 0,
-            isVisible: false
+            isVisible: false,
+            strictDateParsing: strictDateParsing
         }
     },
 
@@ -144,7 +147,7 @@ module.exports = React.createClass({
             newDate = moment(date, format, true)
             // if the new date didn't match our format, see if the native
             // js date can parse it
-            if (!newDate.isValid()) {
+            if (!newDate.isValid() && !this.props.strictDateParsing) {
                 let d = new Date(date)
                 // if native js cannot parse, just make a new date
                 if (isNaN(d.getTime())) {


### PR DESCRIPTION
If strictDateParsing is set, the parsing process will catch bad dates and does
not try to parse the date with the native js date function and does not set
the date to now either. Therefore the computed date will be reported as 'Invalid date'.