### PR TITLE
Allow display format to be different to on blur parsing format

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ Allowed Keys: All formats supported by [moment.js](http://momentjs.com/docs/#/pa
 
 Format of date, which display in input and set in date property.
 
+#### props.parsingFormat
+
+Type: `String` or `Array`
+
+Default: 'props.format'
+
+Allowed Keys: All formats supported by [moment.js](http://momentjs.com/docs/#/parsing/string-format/)
+
+This property allows the parsing format to be different to the display format.
+[Format](http://momentjs.com/docs/#/parsing/string-format/) or [Formats](http://momentjs.com/docs/#/parsing/string-formats/)
+ could be used to parse manually entered dates. The parsing does only happen if the date was entered manually and
+ on blur of the input field gets called.
+
 #### props.date
 
 Type: `String` or `Date`

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -15,6 +15,10 @@ module.exports = React.createClass({
         closeOnSelect: React.PropTypes.bool,
         computableFormat: React.PropTypes.string,
         strictDateParsing: React.PropTypes.bool,
+        parsingFormat: React.PropTypes.oneOfType([
+            React.PropTypes.string,
+            React.PropTypes.arrayOf(React.PropTypes.string)
+        ]),
         date: React.PropTypes.any,
         minDate: React.PropTypes.any,
         maxDate: React.PropTypes.any,
@@ -39,7 +43,8 @@ module.exports = React.createClass({
             format = this.props.format || 'MM-DD-YYYY',
             minView = parseInt(this.props.minView, 10) || 0,
             computableFormat = this.props.computableFormat || 'MM-DD-YYYY',
-            strictDateParsing = this.props.strictDateParsing || false;
+            strictDateParsing = this.props.strictDateParsing || false,
+            parsingFormat = this.props.parsingFormat || format;
 
         return {
             date: date,
@@ -52,7 +57,8 @@ module.exports = React.createClass({
             minView: minView,
             currentView: minView || 0,
             isVisible: false,
-            strictDateParsing: strictDateParsing
+            strictDateParsing: strictDateParsing,
+            parsingFormat: parsingFormat
         }
     },
 
@@ -140,11 +146,12 @@ module.exports = React.createClass({
         let date = this.state.inputValue,
             newDate = null,
             computableDate = null,
-            format = this.state.format
+            format = this.state.format,
+            parsingFormat = this.state.parsingFormat
 
         if (date) {
             // format, with strict parsing true, so we catch bad dates
-            newDate = moment(date, format, true)
+            newDate = moment(date, parsingFormat, true)
             // if the new date didn't match our format, see if the native
             // js date can parse it
             if (!newDate.isValid() && !this.props.strictDateParsing) {


### PR DESCRIPTION
Add prop parsingFormat to allow the parsing format to be different to the display format. The parsing does only happen if the date was entered manually and on blur gets called.