### PR TITLE
Add today text

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ Default: false
 
 If true, the icon next to the input field will not be shown. Make sure you set openOnInputFocus to true if using this.
 
+#### props.hideTouchKeyboard
+
+Type `Boolean`
+
+Default: false
+
+If true, the keyboard won't be shown on touch devices.
+
 #### props.placeholder
 
 Type: `String`
@@ -169,6 +177,14 @@ Type: `String`
 Default: undefined
 
 Value to show in the input text box if no date is set.
+
+#### props.todayText
+
+Type: `String`
+
+Default: `'today'`
+
+'Today' button text.
 
 #### props.inputFieldId
 

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -31,7 +31,8 @@ module.exports = React.createClass({
         placeholder: React.PropTypes.string,
         hideTouchKeyboard: React.PropTypes.bool,
         hideIcon: React.PropTypes.bool,
-        customIcon: React.PropTypes.string
+        customIcon: React.PropTypes.string,
+        todayText: React.PropTypes.string
     },
 
     getInitialState: function() {
@@ -259,7 +260,7 @@ module.exports = React.createClass({
                 break
         }
 
-        let todayText = moment.locale() === 'de' ? 'Heute' : 'Today',
+        let todayText = this.props.todayText || (moment.locale() === 'de' ? 'Heute' : 'Today'),
           calendarClass = cs({
             'input-calendar-wrapper': true,
             'icon-hidden': this.props.hideIcon
@@ -280,7 +281,8 @@ module.exports = React.createClass({
             'fa-calendar': !this.state.isVisible,
             'fa-calendar-o': this.state.isVisible
         })) : null;
-      let readOnly = false;
+
+        let readOnly = false;
 
         if (this.props.hideTouchKeyboard) {
           // do not break server side rendering:


### PR DESCRIPTION
With this prop, users will be able to easily translate 'today'.

Other locale features are handled by moment already.

Also, added `hideTouchKeyboard` prop to README.