### PR TITLE
Added a prop to hide calendar when on blur from the field happens

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -31,6 +31,7 @@ module.exports = React.createClass({
         placeholder: React.PropTypes.string,
         hideTouchKeyboard: React.PropTypes.bool,
         hideIcon: React.PropTypes.bool,
+        hideOnBlur: React.PropTypes.bool,
         customIcon: React.PropTypes.string,
         todayText: React.PropTypes.string
     },
@@ -58,6 +59,7 @@ module.exports = React.createClass({
             minView: minView,
             currentView: minView || 0,
             isVisible: false,
+            hideOnBlur: false,
             strictDateParsing: strictDateParsing,
             parsingFormat: parsingFormat
         }
@@ -177,7 +179,12 @@ module.exports = React.createClass({
         }
 
         if (this.props.onBlur) {
+            this.state.isVisible = this.props.hideOnBlur;
             this.props.onBlur(e, computableDate)
+        }
+
+        if(this.props.hideOnBlur) {
+          this.state.isVisible = !this.state.isVisible;
         }
     },
 


### PR DESCRIPTION
React input calendar doesn't seem to hide when you leave the calendar field by tabbing away, only closes on click away. I thought this may help some of the other people with similar problem.