### PR TITLE
called preventDefault on the event in documentClick to stop it form getting to other...

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,11 +64,13 @@ class Calendar extends React.Component {
       || date && this.state.maxDate && date.isAfter(this.state.maxDate, 'day')
   }
 
-  documentClick = () => {
+  documentClick = e => {
+    e.preventDefault();
     if (!this.state.isCalendar) {
       this.setVisibility(false)
     }
     this.setState({ isCalendar: false })
+
   }
 
   inputBlur = e => {


### PR DESCRIPTION
…handlers, for instance when this component is inside a ``<label>`` it focusses the input and closes the calendar.

This was the case in one of our applications since the Calendar was inside a `<label>`.