### PR TITLE
This allows document clicks to proceed normally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,12 +70,10 @@ class Calendar extends React.Component {
   }
 
   documentClick = e => {
-    e.preventDefault();
     if (!this.state.isCalendar) {
       this.setVisibility(false)
     }
     this.setState({ isCalendar: false })
-
   }
 
   inputBlur = e => {


### PR DESCRIPTION
A click issue is mentioned [here](https://github.com/Rudeg/react-input-calendar/pull/96) but I [(and others)](https://github.com/Rudeg/react-input-calendar/issues/100) feel this is too heavy-handed. 

In my case, this broke `<button type='submit'>` from functioning as a normal form submit button.