### PR TITLE
Make closeOnSelect and month switch play nice together

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ class Calendar extends React.Component {
     }
   }
 
-  setDate = (date, isDayView = true) => {
+  setDate = (date, isDayView = false) => {
     if (this.checkIfDateDisabled(date)) return
 
     this.setState({


### PR DESCRIPTION
Fixes #91 and #97. #91 is already kind of fixed in `master`, but not when it's being used together with `closeOnSelect`.

I tested the following scenarios inside the storybook and they all work as documented:

`<Calendar format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar disabled={true} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar disabled={false} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={false} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={true} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={true} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={true} disabled={true} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={true} disabled={false} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={false} disabled={false} format="DD/MM/YYYY" date="01/01/2016" />`
`<Calendar closeOnSelect={false} disabled={true} format="DD/MM/YYYY" date="01/01/2016" />`