### PR TITLE
Don't update widget until the calendar closes when closeOnSelect=true

### DIFF
--- a/src/day-view.js
+++ b/src/day-view.js
@@ -14,6 +14,7 @@ export default class DayView extends React.Component {
     minDate: PropTypes.any,
     maxDate: PropTypes.any,
     setDate:PropTypes.func,
+    setDateMonthChange:PropTypes.func,
     nextView: PropTypes.func
   }
 
@@ -75,7 +76,7 @@ export default class DayView extends React.Component {
     if (this.props.maxDate && nextDate.isAfter(this.props.maxDate, 'day')) {
       nextDate = this.props.maxDate
     }
-    this.props.setDate(nextDate)
+    this.props.setDateMonthChange(nextDate)
   }
 
   prev = () => {
@@ -83,7 +84,7 @@ export default class DayView extends React.Component {
     if (this.props.minDate && prevDate.isBefore(this.props.minDate, 'day')) {
       prevDate = this.props.minDate
     }
-    this.props.setDate(prevDate)
+    this.props.setDateMonthChange(prevDate)
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,19 @@ class Calendar extends React.Component {
     }
   }
 
+  setDateNoSave = (date) => {
+    if (!this.props.closeOnSelect) {
+      this.setDate(date);
+      return;
+    }
+
+    this.setState((previousState) => {
+      return Object.assign({}, previousState, {
+        date
+      });
+    });
+  }
+
   setVisibility(val) {
     const value = val !== undefined ? val : !this.state.isVisible
     const eventMethod = value ? 'addEventListener' : 'removeEventListener'
@@ -234,6 +247,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             setDate={this.setDate}
+            setDateMonthChange={this.setDate}
           />
         )
         break
@@ -245,7 +259,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             prevView={this.prevView}
-            setDate={this.setDate}
+            setDate={this.setDateNoSave}
           />
         )
         break
@@ -256,7 +270,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             prevView={this.prevView}
-            setDate={this.setDate}
+            setDate={this.setDateNoSave}
           />
         )
         break
@@ -268,6 +282,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             setDate={this.setDate}
+            setDateMonthChange={this.setDate}
           />
         )
     }

--- a/src/index.js
+++ b/src/index.js
@@ -247,7 +247,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             setDate={this.setDate}
-            setDateMonthChange={this.setDate}
+            setDateMonthChange={this.setDateNoSave}
           />
         )
         break
@@ -282,7 +282,7 @@ class Calendar extends React.Component {
             maxDate={this.state.maxDate}
             minDate={this.state.minDate}
             setDate={this.setDate}
-            setDateMonthChange={this.setDate}
+            setDateMonthChange={this.setDateNoSave}
           />
         )
     }

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -6,7 +6,5 @@ import '../../style/index.css'
 storiesOf('Calendar', module).add('default view', () => {
   return <Calendar format="DD/MM/YYYY" date="01/01/2016" />
 }).add('Save on close', () => {
-  return <Calendar format="DD/MM/YYYY" closeOnSelect={true} onChange={(x)=> {
-      console.log('set', x);
-    }}/>
+  return <Calendar format="DD/MM/YYYY" closeOnSelect={true}/>
 })

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -5,4 +5,13 @@ import '../../style/index.css'
 
 storiesOf('Calendar', module).add('default view', () => {
   return <Calendar format="DD/MM/YYYY" date="01/01/2016" />
+}).add('Save on close', () => {
+  const saved = [''];
+  return <div>
+    <Calendar format="DD/MM/YYYY" closeOnSelect={true} onChange={(x)=> {
+      saved[0] = x;
+    }}/>
+    <label>Saved:</label>
+    <p>{saved[0]}</p>
+  </div>
 })


### PR DESCRIPTION
In our application, it's invalid to enter a date that's less than 13 years from today.  We don't want <Calendar> to disable elements of its GUI to prevent this.  We DO want <Calendar> to NOT update the text input field or invoke onChange while the user navigates to an older year/month.

Undesireable Functionality:
* Day view - whenever the user clicks the '<' or '>' to browse to another month, the date gets saved and onChange is invoked.
* Month view - whenever the user clicks the '<' or '>' to browse to another year, the date gets saved and onChange is invoked.
* Year view - whenever the user clicks the '<' or '>' to browse to another decade, the date gets saved and onChange is invoked.

Changes in this PR:
* Day view - whenever the user clicks the '<' or '>' to browse to another month, DON'T save the date or invoke onChange IF closeOnSelect=true, otherwise pre-PR functionality.
* Month view - whenever the user clicks the '<' or '>' to browse to another year, DON'T save the date or invoke onChange IF closeOnSelect=true, otherwise pre-PR functionality.
* Year view - whenever the user clicks the '<' or '>' to browse to another decade, DON'T save the date or invoke onChange IF closeOnSelect=true, otherwise pre-PR functionality.