### PR TITLE
Fixed cs is not defined when using customIcon prop

### DIFF
--- a/src/icon.js
+++ b/src/icon.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import cs from 'classnames'
 
 export default ({ customIcon, hideIcon, disabled }, toggleClick) => {
   if (customIcon == null) {


### PR DESCRIPTION
When using the customIcon prop it throws a "cs is not defined error". Classnames import was missing.