### PR TITLE
Adds 2 new setting options; Resolves issue #122

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,29 @@ import Calendar from 'react-input-calendar'
  - default: `null`
  - set the selectable maximum date
 
+#### props.defaultView
+
+ - `Int` (from 0 to 2)
+ - default: `0` (DaysView)
+ - Set default view displayed. Values:
+    - 0 - days
+    - 1 - months
+    - 2 - years
+
 #### props.minView
 
  - `Int` (from 0 to 2)
  - default: `0` (DaysView)
  - Set minimal view. Values:
-  - 0 - days
-  - 1 - months
-  - 2 - years
+    - 0 - days
+    - 1 - months
+    - 2 - years
+
+#### props.displayYrWithMonth
+
+ - `Boolean`
+ - default: `false`
+ - If set `true`, the day view's header will show an abbreviated month and full year. Example: Instead of the header displaying 'December', it will display 'Dec 2016'
 
 #### props.computableFormat
 

--- a/src/day-view.js
+++ b/src/day-view.js
@@ -15,7 +15,8 @@ export default class DayView extends React.Component {
     maxDate: PropTypes.any,
     setInternalDate: PropTypes.func,
     setInputDate: PropTypes.func,
-    nextView: PropTypes.func
+    nextView: PropTypes.func,
+    displayYrWithMonth: PropTypes.bool
   }
 
   getDays() {
@@ -112,7 +113,8 @@ export default class DayView extends React.Component {
         value={item.label}
       />
     ))
-    const currentDate = this.props.date ? this.props.date.format('MMMM') : moment().format('MMMM')
+    const format = this.props.displayYrWithMonth ? 'MMM YYYY' : 'MMMM';
+    const currentDate = this.props.date ? this.props.date.format(format) : moment().format(format);
 
     return (
       <div className="view days-view" onKeyDown={this.keyDown}>

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ class Calendar extends React.Component {
     const minDate = props.minDate ? moment(props.minDate, parsingFormat) : null
     const maxDate = props.maxDate ? moment(props.maxDate, parsingFormat) : null
     const minView = parseInt(props.minView, 10) || 0
+    const defaultView = parseInt(props.defaultView, 10) || 0
+    const displayYrWithMonth = props.displayYrWithMonth || false;
 
     const keyboardDisabled = props.keyboardDisabled;
     this.state = {
@@ -34,11 +36,12 @@ class Calendar extends React.Component {
       inputValue: date ? date.format(format) : undefined,
       views: ['days', 'months', 'years'],
       minView,
-      currentView: minView || 0,
+      currentView: defaultView || 0,
       isVisible: false,
       strictDateParsing,
       parsingFormat,
-      keyboardDisabled
+      keyboardDisabled,
+      displayYrWithMonth
     }
   }
 
@@ -244,7 +247,7 @@ class Calendar extends React.Component {
 
   getView() {
     const calendarDate = this.state.date || moment()
-    const { maxDate, minDate } = this.state
+    const { maxDate, minDate, displayYrWithMonth } = this.state
     const props = {
       date: calendarDate,
       nextView: this.nextView,
@@ -252,7 +255,8 @@ class Calendar extends React.Component {
       setInternalDate: this.setInternalDate,
       prevView: this.prevView,
       maxDate,
-      minDate
+      minDate,
+      displayYrWithMonth
     }
 
     switch (this.state.currentView) {

--- a/src/index.js
+++ b/src/index.js
@@ -25,8 +25,9 @@ class Calendar extends React.Component {
     const minView = parseInt(props.minView, 10) || 0
     const defaultView = parseInt(props.defaultView, 10) || 0
     const displayYrWithMonth = props.displayYrWithMonth || false;
-
+    const currentView = (defaultView < minView) ? minView : defaultView;
     const keyboardDisabled = props.keyboardDisabled;
+
     this.state = {
       date,
       minDate,
@@ -36,7 +37,7 @@ class Calendar extends React.Component {
       inputValue: date ? date.format(format) : undefined,
       views: ['days', 'months', 'years'],
       minView,
-      currentView: defaultView || 0,
+      currentView,
       isVisible: false,
       strictDateParsing,
       parsingFormat,

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -14,6 +14,12 @@ storiesOf('Calendar', module)
     </div>
   ))
   .add('locale example', () => <Calendar locale="de" format="DD/MM/YYYY" date="01/01/2016" />)
+  .add('default view month', () => (
+    <Calendar format="DD/MM/YYYY" date="01/01/2016" defaultView={1} />
+  ))
+  .add('month/year display (day view)', () => (
+    <Calendar format="DD/MM/YYYY" date="01/01/2016" displayYrWithMonth={true} />
+  ))
 
 class FocusDateInput extends React.Component {
   constructor(props) {


### PR DESCRIPTION
Added two new setting options:
1. displayYrWithMonth {boolean}: Allows the user to change the header on Day View from just month to month and year. Default is false.
2. defaultView {int} : lets the user set the view that they want the calendar to open in. Default is 0.
Notes: 
- if the user sets the minView but not defaultView, the currentView is defaulted to minView.
- if the user sets the minView higher than the defaultView, the currentView is default to minView.
- else the currentView is set to defaultView. 