### PR TITLE
Add input change handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ import Calendar from 'react-input-calendar'
  - `Function`
  - default: `null`
  - Set a function that will be triggered whenever there is a change in the selected date. It will return the date in the  `props.computableFormat` format.
+ 
+ #### props.onInputChange
+ 
+  - `Function`
+  - default: `null`
+  - Set a function that will be triggered within the input box's onChange handler, before the new value is set. It will take the event object 
+  and return a modified value. 
 
 #### props.onBlur
 

--- a/src/index.js
+++ b/src/index.js
@@ -120,7 +120,13 @@ class Calendar extends React.Component {
 
   changeDate = e => {
     //eslint-disable-line
-    this.setState({ inputValue: e.target.value })
+    let value = e.target.value;
+
+    if (this.props.onInputChange) {
+      value = this.props.onInputChange(e);
+    }
+
+    this.setState({ inputValue: value })
   }
 
   checkIfDateDisabled(date) {
@@ -364,7 +370,8 @@ Calendar.propTypes = {
   disabled: PropTypes.bool,
   focused: PropTypes.bool,
   locale: PropTypes.string,
-  keyboardDisabled: PropTypes.bool
+  keyboardDisabled: PropTypes.bool,
+  onInputChange: PropTypes.func,
 }
 
 export default Calendar


### PR DESCRIPTION
Added 'onInputChange' to be triggered in Calendar's onChange handler (changeDate) to modify the value before it is set to state. 

This allows users to pass in a method to modify the input string before it is set. For example, the user can filter characters by length or values, auto-fill back slashes, and auto-correct. 

